### PR TITLE
Modify sleep function to handle negative input

### DIFF
--- a/user/sleep.c
+++ b/user/sleep.c
@@ -14,8 +14,9 @@ int main(int argc, char *argv[])
         exit(1);
     }
 
-    sleep_sec = atoi(argv[1]);
-    if (sleep_sec > 0)
+    sleep_sec = atoi(argv[1] + 1); 
+    if (argv[1][0] == '-') sleep_sec *= -1;
+    if (sleep_sec >= 0)
     {
         sleep(sleep_sec);
     }


### PR DESCRIPTION
"atoi" compile negative numbers into zero. So in order to avoid this: we need to pass the string without "-" and then if the string contains "-" multiply number by -1. So that, we can include zero sleep as a correct number for the function to work.